### PR TITLE
test(jinja_inline): add highlight tests to sync with nvim-treesitter

### DIFF
--- a/tree-sitter-jinja_inline/queries/highlights.scm
+++ b/tree-sitter-jinja_inline/queries/highlights.scm
@@ -71,11 +71,7 @@
   "as"
 ] @keyword.import
 
-(import_statement
-  (identifier) @variable)
-
-(import_as
-  (identifier) @variable)
+(identifier) @variable
 
 [
   "if"
@@ -109,11 +105,33 @@
 
 (expression
   "."
-  (expression)+ @variable.member)
+  (expression
+    (binary_expression
+      .
+      (unary_expression
+        (primary_expression
+          (identifier) @variable.member)))))
+
+(expression
+  "."
+  (expression
+    (binary_expression
+      (binary_expression
+        (unary_expression
+          (primary_expression
+            (identifier) @variable.member))))))
 
 (assignment_expression
   "."
   (identifier)+ @variable.member)
+
+; jinja filters
+(binary_expression
+  (binary_operator
+    "|")
+  (unary_expression
+    (primary_expression
+      (identifier) @function.call)))
 
 (inline_trans
   "_" @function.builtin)

--- a/tree-sitter-jinja_inline/test/highlight/filters.jinja_inline
+++ b/tree-sitter-jinja_inline/test/highlight/filters.jinja_inline
@@ -1,0 +1,19 @@
+#  name|striptags|title
+## ^^^^ @variable
+##      ^^^^^ @function.call
+##                ^^^^^ @function.call
+
+#  listx|join(', ')
+## ^^^^^ @variable
+##       ^^^^ @function.call
+##            ^^^^ @string
+
+#  listx|join(str)
+## ^^^^^ @variable
+##       ^^^^ @function.call #}
+##            ^^^ @variable.parameter #}
+
+#  foo.bar|random
+## ^^^ @variable
+##     ^^^ @variable.member
+##         ^^^^^^ @function.call

--- a/tree-sitter-jinja_inline/test/highlight/tests.jinja_inline
+++ b/tree-sitter-jinja_inline/test/highlight/tests.jinja_inline
@@ -1,0 +1,13 @@
+#  if loop.index is divisibleby 3
+##    ^^^^ @variable
+##         ^^^^^ @variable.member
+##                  ^^^^^^^^^^ @keyword.operator
+
+#  if loop.index is divisibleby(3)
+##    ^^^^ @variable
+##         ^^^^^ @variable.member
+
+#  if foo.bar.baz is divisibleby 3
+##    ^^^ @variable
+##        ^^^ @variable.member
+##            ^^^ @variable.member

--- a/tree-sitter-jinja_inline/test/highlight/variables.jinja_inline
+++ b/tree-sitter-jinja_inline/test/highlight/variables.jinja_inline
@@ -1,0 +1,21 @@
+#  foo
+## ^^^ @variable
+
+#  foo.bar
+## ^^^ @variable
+##     ^^^ @variable.member
+
+#  foo['bar']
+## ^^^ @variable
+##     ^^^^^ @string
+
+#  foo.bar.baz
+## ^^^ @variable
+##     ^^^ @variable.member
+##         ^^^ @variable.member
+
+#  foo.bar + baz.qux
+## ^^^ @variable
+##     ^^^ @variable.member
+##           ^^^ @variable
+##               ^^^ @variable.member


### PR DESCRIPTION
Sync queries with nvim-treesitter. Add syntax highlighting tests: these test against jinja_inline directly (since it does support comments, and the queries don't require any neovim-specific stuff).

```
$ tree-sitter test
...
syntax highlighting:
    ✓ tests.jinja_inline (8 assertions)
    ✓ variables.jinja_inline (12 assertions)
    ✓ filters.jinja_inline (12 assertions)
```

If you regenerate, you can reproduce the crash from #37

```
$ tree-sitter generate
$ tree-sitter test
...
tree-sitter: /usr/src/debug/tree-sitter/tree-sitter/lib/src/./query.c:1771: ts_query__analyze_patterns: Assertion `analysis.final_step_indices.size > 0' failed.
Aborted                    (core dumped) tree-sitter test
```

This does not fix any issue, but makes it easier to reproduce locally.

Relates: #37