### PR TITLE
fix: remove duplicate captures in jinja_inline highlights

### DIFF
--- a/tree-sitter-jinja_inline/queries/highlights.scm
+++ b/tree-sitter-jinja_inline/queries/highlights.scm
@@ -56,7 +56,6 @@
   "endmacro"
   "endcall"
   "endset"
-  "endtrans"
   "endautoescape"
   "required"
 ] @keyword
@@ -148,14 +147,12 @@
   [
     "boolean"
     "even"
-    "in"
     "mapping"
     "sequence"
     "callable"
     "integer"
     "ne"
     "string"
-    "defined"
     "filter"
     "iterable"
     "none"


### PR DESCRIPTION
## Summary

Three duplicate/conflicting captures found in `tree-sitter-jinja_inline/queries/highlights.scm`, detected by [`ts_query_ls`](https://github.com/ribru17/ts_query_ls) lint.

### 1. Duplicate `"endtrans"` in keyword alternation

`"endtrans"` appears twice in the same alternation, causing a lint error.

### 2. `"in"` in `builtin_test` conflicts with `@keyword.repeat`

Already captured as `@keyword.repeat`. Removed from `builtin_test`.

### 3. `"defined"` in `builtin_test` conflicts with `@constant`

Already captured as `@constant` at line 13. Removed from `builtin_test`.